### PR TITLE
Allow to use status_id column as status entity

### DIFF
--- a/mfd/model.go
+++ b/mfd/model.go
@@ -526,7 +526,7 @@ func (s *Search) ForeignAttribute() (entity, attribute string) {
 }
 
 func IsStatus(name string) bool {
-	return strings.ToLower(name) == "statusid" || strings.ToLower(name) == "status"
+	return strings.ToLower(name) == "statusid" || strings.ToLower(name) == "status" || strings.ToLower(name) == "status_id"
 }
 
 func IsArraySearch(search string) bool {


### PR DESCRIPTION
Hi, I've got all db columns in snake_case notation. And when I want to generate model (`mfd-generator model ...`) there is an error:
`2020/12/07 21:43:32 generate error: fk entity Status not found for StatusID column in User entity common namespace`.

So, adding `status_id` to check function resolves an issue.