### PR TITLE
Update vt rpc generation, update readme, use Addable/Updatable fields in repo generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MDF Generator
+# MFD Generator
 
 **mfd generator** призван облегчить работу с базой данных путем генерирования моделей, поисков и валидаторов, а также сопутствующих сущностей вплоть до интерфейса админки.
 Проект включает в себя несколько генераторов, каждый из которых генерирует xml, go, js разных уровней.
@@ -22,35 +22,25 @@
 
 Описание форматов xml файлов можно найти в соответствующих генераторах [xml](/generators/xml), [xml-vt](/generators/xml-vt) и [xml-lang](/generators/xml-lang)
 
-### CHANGELOG
+# Command line usage
+```
+Usage:
+  mfd-generator [flags]
+  mfd-generator [command]
 
-#### v0.0.1  
-**xml**
-- `-o --output` renamed to `-m --mfd` 
-- `-p --pkgs`  renamed to `-n --namespaces`  
-- added `-p --print` flag to print value for `namespaces` flag based on current project. flag was moved from `model` generator
+Available Commands:
+  help        Help about any command
+  model       Create golang model from xml
+  repo        Create repo from xml
+  server      Run web server with generators
+  template    Create vt template from xml
+  vt          Create vt from xml
+  xml         Create or update project base with namespaces and entities
+  xml-lang    Create lang xml from mfd
+  xml-vt      Create vt xml from mfd
 
-**xml-vt**
-- generator command renamed from `xml vt` to `xml-vt`
-- `-p --ns`  renamed to `-n --namespaces`    
+Flags:
+  -h, --help   help for mfd
 
-**xml-lang**
-- generator command renamed from `xml lang` to `xml-lang`
-
-**model**
-- `-n --ns` flag renamed to `-p --print` and moved to **xml** generator
-- `-p --package` flag now not required. if flag not set - last element of output path will be used
-
-#### v0.0.2 
-
-**repo**
-- `-n --ns`  renamed to `-n --namespaces` 
-- `-p --package` flag now not required. if flag not set - last element of output path will be used
-
-**vt**
-- `-n --ns`  renamed to `-n --namespaces`
-- `-x --model-pkg`  renamed to `-x --model`
-
-**vt-template** 
-- `-n --ns`  renamed to `-n --namespaces`
-- disabled custom templates flags
+Use "mfd-generator [command] --help" for more information about a command.
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 )
 
 var root = &cobra.Command{
-	Use:   "mfd",
+	Use:   "mfd-generator",
 	Short: "",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/generators/repo/repo.go
+++ b/generators/repo/repo.go
@@ -93,9 +93,13 @@ type EntityData struct {
 	HasRelations bool
 	Relations    []string
 
-	Columns         []AttributeData
-	HasNotAddable   bool
+	Columns []AttributeData
+
+	HasNotAddable bool
+	NotAddable    []string
+
 	HasNotUpdatable bool
+	NotUpdatable    []string
 }
 
 // PackEntity packs mfd entity to template data
@@ -106,6 +110,8 @@ func PackEntity(entity mfd.Entity, options Options) EntityData {
 	hasStatus := false
 	hasNotAddable := false
 	hasNotUpdatable := false
+	var notAddable []string
+	var notUpdatable []string
 	var pks []PKPair
 
 	imports := mfd.NewSet()
@@ -138,10 +144,12 @@ func PackEntity(entity mfd.Entity, options Options) EntityData {
 
 		if !column.IsAddable() {
 			hasNotAddable = true
+			notAddable = append(notAddable, column.Name)
 		}
 
 		if !column.IsUpdatable() {
 			hasNotUpdatable = true
+			notUpdatable = append(notUpdatable, column.Name)
 		}
 
 		columns = append(columns, AttributeData{
@@ -188,9 +196,12 @@ func PackEntity(entity mfd.Entity, options Options) EntityData {
 		Relations:    relations,
 		HasRelations: len(relations) > 0,
 
-		Columns:         columns,
-		HasNotAddable:   hasNotAddable,
+		Columns:       columns,
+		HasNotAddable: hasNotAddable,
+		NotAddable:    notAddable,
+
 		HasNotUpdatable: hasNotUpdatable,
+		NotUpdatable:    notUpdatable,
 	}
 }
 

--- a/generators/repo/template.go
+++ b/generators/repo/template.go
@@ -102,7 +102,7 @@ func ({{$.ShortVarName}}r {{$.Name}}Repo) Count{{.NamePlural}}(ctx context.Conte
 func ({{$.ShortVarName}}r {{$.Name}}Repo) Add{{.Name}}(ctx context.Context, {{.VarName}} *{{.Name}}, ops ...OpFunc) (*{{.Name}}, error) {
 	q := {{$.ShortVarName}}r.db.ModelContext(ctx, {{.VarName}})
 	applyOps(q, ops...)
-	_, err := q.Insert()
+	_, err := q{{if .HasNotAddable}}.ExcludeColumn({{range .NotAddable}}Columns.{{$e.Name}}.{{.}},{{end}}){{end}}.Insert()
 
 	return {{.VarName}}, err
 }
@@ -111,7 +111,7 @@ func ({{$.ShortVarName}}r {{$.Name}}Repo) Add{{.Name}}(ctx context.Context, {{.V
 func ({{$.ShortVarName}}r {{$.Name}}Repo) Update{{.Name}}(ctx context.Context, {{.VarName}} *{{.Name}}, ops ...OpFunc) (bool, error) {
 	q := {{$.ShortVarName}}r.db.ModelContext(ctx, {{.VarName}}).WherePK()
 	applyOps(q, ops...)
-	res, err := q.Update()
+	res, err := q{{if .HasNotUpdatable}}.ExcludeColumn({{range .NotUpdatable}}Columns.{{$e.Name}}.{{.}},{{end}}){{end}}.Update()
 	if err != nil {
 		return false, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/spf13/cobra v1.1.3
 	github.com/vmkteam/zenrpc/v2 v2.2.1
+	golang.org/x/text v0.3.3
 )
 
 require (

--- a/mfd/files.go
+++ b/mfd/files.go
@@ -13,15 +13,23 @@ import (
 	"strings"
 
 	"github.com/dizzyfool/genna/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func raw(str string) template.HTML {
 	return template.HTML(str)
 }
 
+func title(str string) template.HTML {
+	c := cases.Title(language.Und, cases.NoLower)
+	return template.HTML(c.String(str))
+}
+
 var TemplateFunctions = template.FuncMap{
 	"raw":     raw,
 	"ToLower": strings.ToLower,
+	"title":   title,
 }
 
 type Packer func(*Namespace) (interface{}, error)


### PR DESCRIPTION
- Update README
- Exclude entity fields from adding/updating in db repository generation if Addable/Updatable is false
- Add relation repositories generation in vt rpc service
- Use Summary structs for vt rpc model generation
- Remove ToDB converting for vt rpc model relations
- Update vt rpc server default template